### PR TITLE
Add South African Rand currency code (ZAR) to lib

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -446,7 +446,7 @@ class enrol_paystack_plugin extends enrol_plugin
      */
     public function get_currencies()
     {
-        $codes = array('NGN', 'USD', 'GHS');
+        $codes = array('NGN', 'USD', 'GHS', 'ZAR');
         $currencies = array();
         foreach ($codes as $c) {
             $currencies[$c] = new lang_string($c, 'core_currencies');


### PR DESCRIPTION
Currency missing for South African users. Already supported by API