### PR TITLE
Defined enrol_paystack_charge_exception_handler

### DIFF
--- a/classes/util.php
+++ b/classes/util.php
@@ -72,7 +72,7 @@ final class util {
         return function($ex) {
             $info = get_exception_info($ex);
 
-            $logerrmsg = "enrol_paystack Webhook exception handler: ".$info->message;
+            $logerrmsg = "enrol_paystack exception handler: ".$info->message;
             if (debugging('', DEBUG_NORMAL)) {
                 $logerrmsg .= ' Debug: '.$info->debuginfo."\n".format_backtrace($info->backtrace, true);
             }
@@ -86,21 +86,4 @@ final class util {
         };
     }
 
-    public static function enrol_paystack_charge_exception_handler() {
-        return function($ex) {
-            $info = get_exception_info($ex);
-
-            $logerrmsg = "enrol_paystack charge exception handler: ".$info->message;
-            if (debugging('', DEBUG_NORMAL)) {
-                $logerrmsg .= ' Debug: '.$info->debuginfo."\n".format_backtrace($info->backtrace, true);
-            }
-            error_log($logerrmsg);
-
-            if (http_response_code() == 200) {
-                http_response_code(500);
-            }
-
-            exit(0);
-        };
-    }
 }

--- a/classes/util.php
+++ b/classes/util.php
@@ -85,4 +85,22 @@ final class util {
             exit(0);
         };
     }
+
+    public static function enrol_paystack_charge_exception_handler() {
+        return function($ex) {
+            $info = get_exception_info($ex);
+
+            $logerrmsg = "enrol_paystack charge exception handler: ".$info->message;
+            if (debugging('', DEBUG_NORMAL)) {
+                $logerrmsg .= ' Debug: '.$info->debuginfo."\n".format_backtrace($info->backtrace, true);
+            }
+            error_log($logerrmsg);
+
+            if (http_response_code() == 200) {
+                http_response_code(500);
+            }
+
+            exit(0);
+        };
+    }
 }

--- a/verify.php
+++ b/verify.php
@@ -38,7 +38,10 @@ require_login();
 
 // Paystack does not like when we return error messages here,
 // the custom handler just logs exceptions and stops.
-set_exception_handler('enrol_paystack_charge_exception_handler');
+//set_exception_handler('enrol_paystack_charge_exception_handler');
+
+set_exception_handler(array('enrol_paystack\util', 'enrol_paystack_charge_exception_handler'));
+
 
 // Make sure we are enabled in the first place.
 if (!enrol_is_enabled('paystack')) {

--- a/verify.php
+++ b/verify.php
@@ -40,7 +40,7 @@ require_login();
 // the custom handler just logs exceptions and stops.
 //set_exception_handler('enrol_paystack_charge_exception_handler');
 
-set_exception_handler(array('enrol_paystack\util', 'enrol_paystack_charge_exception_handler'));
+set_exception_handler(array('enrol_paystack\util', 'get_exception_handler'));
 
 
 // Make sure we are enabled in the first place.


### PR DESCRIPTION
In this milestone, we defined the enrol handler that was called initially but not defined. 

In Moodle version 3.4, where we tested, the enrolment was not failing but on version 4.2 it fails with an error "enrol_paystack_charge_exception_handler" not found. 
 
 After our investigation, we discovered that the enrol_handler method was called but not declared. Hence, we created this method in the util.php file.